### PR TITLE
Improve regex matching

### DIFF
--- a/device_test.go
+++ b/device_test.go
@@ -206,3 +206,28 @@ func TestRegThread(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+
+func benchmarkUserAgent(b *testing.B, ua string) {
+	dd.SkipBotDetection = true
+	// parse and then reset the timer,
+	// the first call to .Parse() will compile some regexes
+	// and we just want to measure time to match the regex instead
+	dd.Parse(ua)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dd.Parse(ua)
+	}
+}
+
+func BenchmarkParseDeviceInfoForBrowser(b *testing.B) {
+	benchmarkUserAgent(b, `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0) Gecko/20100101 Firefox/85.0`)
+}
+
+func BenchmarkParseDeviceInfoFor(b *testing.B) {
+	benchmarkUserAgent(b, `Mozilla/5.0 (Linux; Android 4.4.3; Build/KTU84L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36`)
+}
+
+func BenchmarkParseDeviceInfoForMobile(b *testing.B) {
+	benchmarkUserAgent(b, `Mozilla/5.0 (Linux; Android 4.4.4; MX4 Pro Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36; 360 Aphone Browser (6.9.7)`)
+}

--- a/device_test.go
+++ b/device_test.go
@@ -62,6 +62,7 @@ func TestVersionTruncation(t *testing.T) {
 		assert.Equal(t, info.GetOs().Version, v[1])
 		assert.Equal(t, info.GetClient().Version, v[2])
 	}
+	SetVersionTruncation(VERSION_TRUNCATION_NONE)
 }
 
 func TestBot(t *testing.T) {

--- a/parser/regexp.go
+++ b/parser/regexp.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"fmt"
+	"log"
 	"regexp"
 	goregexp "regexp"
 	"strings"
@@ -57,7 +57,7 @@ func (r *Regexp) Compile() error {
 
 func (r *Regexp) MustCompile() {
 	if err := r.Compile(); err != nil {
-		panic(fmt.Sprintf("Could not compile regex '%s': %v", r.expression, err))
+		log.Panicf("Could not compile regex '%s': %v", r.expression, err)
 	}
 }
 

--- a/parser/regexp.go
+++ b/parser/regexp.go
@@ -1,0 +1,100 @@
+package parser
+
+import (
+	"fmt"
+	"regexp"
+	goregexp "regexp"
+	"strings"
+
+	regexp2 "github.com/dlclark/regexp2"
+)
+
+type Regexp struct {
+	expression string
+	regexpGo *goregexp.Regexp
+	regexpLib *regexp2.Regexp
+}
+
+func NewRegexp(re string) *Regexp {
+	r := &Regexp{expression: re}
+	r.MustCompile()
+	return r
+}
+
+func (r *Regexp) compileGoRegex() error {
+		// Make some adjustments for a different regex engine than upstream matomo
+		rg := r.expression
+		rg = strings.Replace(rg, `/`, `\/`, -1)
+		rg = strings.Replace(rg, `++`, `+`, -1)
+		rg = strings.Replace(rg, `\_`, `_`, -1)
+		// if we find `\_` again, the original was `\\_`,
+		// so restore that so the regex engine does not attempt to escape `_`
+		rg = strings.Replace(rg, `\_`, `\\_`, -1)
+
+		str := `(?i)(?:^|[^A-Z0-9-_]|[^A-Z0-9-]_|sprd-)(?:` + rg + ")"
+
+		var err error
+		r.regexpGo, err = regexp.Compile(str)
+		return err
+}
+
+func (r *Regexp) compileLibRegex() error {
+		// Make some adjustments for a different regex engine than upstream matomo
+		rg := r.expression
+		rg = strings.Replace(rg, `/`, `\/`, -1)
+		rg = strings.Replace(rg, `++`, `+`, -1)
+		rg = strings.Replace(rg, `\_`, `_`, -1)
+		// if we find `\_` again, the original was `\\_`,
+		// so restore that so the regex engine does not attempt to escape `_`
+		rg = strings.Replace(rg, `\_`, `\\_`, -1)
+
+		str := `(?:^|[^A-Z0-9-_]|[^A-Z0-9-]_|sprd-)(?:` + rg + ")"
+
+		var err error
+		r.regexpLib, err = regexp2.Compile(str, regexp2.IgnoreCase)
+		return err
+}
+
+func (r *Regexp) Compile() error {
+	if r.regexpGo == nil && r.regexpLib == nil {
+		if err := r.compileGoRegex(); err != nil {
+			return r.compileLibRegex()
+		}
+	}
+	return nil
+}
+
+func (r *Regexp) MustCompile() {
+	if err := r.Compile(); err != nil {
+		panic(fmt.Sprintf("Could not compile regex '%s': %v", r.expression, err))
+	}
+}
+
+func (r *Regexp) MatchString(ua string) bool {
+	r.MustCompile()
+
+	if r.regexpGo != nil {
+		return r.regexpGo.MatchString(ua)
+	}
+
+	match, _ := r.regexpLib.MatchString(ua)
+	return match
+}
+
+func (r *Regexp) FindStringSubmatch(ua string) []string {
+	r.MustCompile()
+
+	if r.regexpGo != nil {
+		return r.regexpGo.FindStringSubmatch(ua)
+	}
+
+	if match, err := r.regexpLib.FindStringMatch(ua); err == nil && match != nil {
+		matches := make([]string, match.GroupCount())
+		for i, g := range match.Groups() {
+			matches[i] = g.String()
+		}
+		return matches
+	}
+	return nil
+}
+


### PR DESCRIPTION
Regex's were running a bit slow. Well it's because this library uses [regexp2](https://github.com/dlclark/regexp2) which implements look arounds, which go's `regexp` does not support. Matomo relies on good amount of lookarounds, but this hurts performance.

Wouldn't it be nice to use `regexp2` when the regex needs lookarounds, and go's `regexp` when it does not?

This PR abstracts away which regexp implementation we're using so that things can run faster _most_ of the time.

Out of the several benchmark tests I've written, I'm seeing parsing time decrease by ~40%.

Before this pr:
```
λ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/muxinc/devicedetector
BenchmarkParseDeviceInfoForBrowser-12                 50          24958820 ns/op
BenchmarkParseDeviceInfoFor-12                        33          35534547 ns/op
BenchmarkParseDeviceInfoForMobile-12                  54          26580086 ns/op
PASS
ok      github.com/muxinc/devicedetector        7.008s
```

After:
```
λ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/muxinc/devicedetector
BenchmarkParseDeviceInfoForBrowser-12                 90          13884112 ns/op
BenchmarkParseDeviceInfoFor-12                        58          20383983 ns/op
BenchmarkParseDeviceInfoForMobile-12                  99          13111794 ns/op
PASS
ok      github.com/muxinc/devicedetector        7.244s

```