### PR TITLE
Samsung Regex for TV needs to be parsed after mobile

### DIFF
--- a/device_detector.go
+++ b/device_detector.go
@@ -78,12 +78,12 @@ func NewDeviceDetector(dir string) (*DeviceDetector, error) {
 	deviceDir := filepath.Join(dir, "device")
 	d.deviceParsers = device.NewDeviceParsers(deviceDir,
 		[]string{
-			device.ParserNameHbbTv,
 			device.ParserNameConsole,
 			device.ParserNameCar,
 			device.ParserNameCamera,
 			device.ParserNamePortableMediaPlayer,
 			device.ParserNameMobile,
+			device.ParserNameHbbTv,
 		})
 
 	d.botParsers = []BotParser{

--- a/device_test.go
+++ b/device_test.go
@@ -96,18 +96,19 @@ func TestBot(t *testing.T) {
 
 func TestTypeMethods(t *testing.T) {
 	data := map[string][]bool{
-		`Googlebot/2.1 (http://www.googlebot.com/bot.html)`: []bool{true, false, false},
-		`Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36`: []bool{false, true, false},
-		`Mozilla/5.0 (Linux; Android 4.4.3; Build/KTU84L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36`:         []bool{false, true, false},
-		`Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)`:                                                                    []bool{false, false, true},
-		`Mozilla/3.01 (compatible;)`: []bool{false, false, false},
+		`Googlebot/2.1 (http://www.googlebot.com/bot.html)`: []bool{true, false, false, false},
+		`Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36`: []bool{false, true, false, false},
+		`Mozilla/5.0 (Linux; Android 4.4.3; Build/KTU84L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36`:         []bool{false, true, false, false},
+		`Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)`:                                                                    []bool{false, false, true, false},
+		`Mozilla/3.01 (compatible;)`: []bool{false, false, false, false},
 		// Mobile only browsers:
-		`Opera/9.80 (J2ME/MIDP; Opera Mini/9.5/37.8069; U; en) Presto/2.12.423 Version/12.16`:                                                                                          []bool{false, true, false},
-		`Mozilla/5.0 (X11; U; Linux i686; th-TH@calendar=gregorian) AppleWebKit/534.12 (KHTML, like Gecko) Puffin/1.3.2665MS Safari/534.12`:                                            []bool{false, true, false},
-		`Mozilla/5.0 (Linux; Android 4.4.4; MX4 Pro Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36; 360 Aphone Browser (6.9.7)`: []bool{false, true, false},
-		`Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; xx) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/6DE`:                                           []bool{false, true, false},
+		`Opera/9.80 (J2ME/MIDP; Opera Mini/9.5/37.8069; U; en) Presto/2.12.423 Version/12.16`:                                                                                          []bool{false, true, false, false},
+		`Mozilla/5.0 (X11; U; Linux i686; th-TH@calendar=gregorian) AppleWebKit/534.12 (KHTML, like Gecko) Puffin/1.3.2665MS Safari/534.12`:                                            []bool{false, true, false, false},
+		`Mozilla/5.0 (Linux; Android 4.4.4; MX4 Pro Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36; 360 Aphone Browser (6.9.7)`: []bool{false, true, false, false},
+		`Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; xx) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/6DE`:                                           []bool{false, true, false, false},
 		// useragent containing non unicode chars
-		`Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; PMP7380D3G Build/JZO54K) AppleWebKit/534.30 (KHTML, ÃÂºÃÂ°ÃÂº Gecko) Version/4.0 Safari/534.30`: []bool{false, true, false},
+		`Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; PMP7380D3G Build/JZO54K) AppleWebKit/534.30 (KHTML, ÃÂºÃÂ°ÃÂº Gecko) Version/4.0 Safari/534.30`:                                                                                                                                []bool{false, true, false, false},
+		`Mozilla/5.0 (Linux; Android 13; SM-G781V Build/TP1A.220624.014; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/113.0.5672.131 Mobile Safari/537.36RCAppMobile/23.2.15 (RingCentral; Samsung SM-G781V; Android/13; Scale/3.1875; build.19681; rev.64114d64cf9) `: []bool{false, true, false, false},
 	}
 	for k, v := range data {
 		dd.DiscardBotInformation = true
@@ -115,6 +116,7 @@ func TestTypeMethods(t *testing.T) {
 		assert.Equal(t, info.IsBot(), v[0], k)
 		assert.Equal(t, info.IsMobile(), v[1], k)
 		assert.Equal(t, info.IsDesktop(), v[2], k)
+		assert.Equal(t, DEVICE_TYPE_TV == info.GetDeviceType(), v[3], k)
 	}
 }
 
@@ -207,7 +209,6 @@ func TestRegThread(t *testing.T) {
 	}
 	wg.Wait()
 }
-
 
 func benchmarkUserAgent(b *testing.B, ua string) {
 	dd.SkipBotDetection = true


### PR DESCRIPTION
Moving the TV parsing to the end fixes the issue of the TV regex having `regex: 'Samsung|Maple_2011'` which kinda matches pretty much anything with "Samsung".

Prior to the changes in ordering this:
`Mozilla/5.0 (Linux; Android 13; SM-G781V Build/TP1A.220624.014; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/113.0.5672.131 Mobile Safari/537.36RCAppMobile/23.2.15 (RingCentral; Samsung SM-G781V; Android/13; Scale/3.1875; build.19681; rev.64114d64cf9)`

was failing the test and being categorized as TV (`v[3]` in the test tests for tv now)